### PR TITLE
Deregstier MTS in the destructor

### DIFF
--- a/src/mtsne.cpp
+++ b/src/mtsne.cpp
@@ -45,6 +45,15 @@ struct MTSNE : public clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::
                 f = 0.f;
     }
 
+    ~MTSNE()
+    {
+        if (mtsClient)
+        {
+            MTS_DeregisterClient(mtsClient);
+            mtsClient = nullptr;
+        }
+    }
+
     MTSClient *mtsClient{nullptr};
     double secondsPerSample{0.f};
 
@@ -65,7 +74,10 @@ struct MTSNE : public clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::
     void deactivate() noexcept override
     {
         if (mtsClient)
+        {
             MTS_DeregisterClient(mtsClient);
+            mtsClient = nullptr;
+        }
     }
 
     bool implementsNotePorts() const noexcept override { return true; }


### PR DESCRIPTION
If ::deactivate isn't called the MTS client wouldn't deregister; make it so ::deactivate wins but if not called ~MTSNE also does a deregister if we have a live client.

Closes #10